### PR TITLE
bad argument #1 to 'select' (index out of range) fix

### DIFF
--- a/Core/Math.lua
+++ b/Core/Math.lua
@@ -78,6 +78,9 @@ function E:ColorGradient(perc, ...)
 	local num = value / 3
 	local segment, relperc = modf(perc*(num - 1))
 	local forSelect = (segment*3) + 1
+	if forSelect ~= forSelect then
+		return ...
+    end
 	if forSelect >= select("#",...) then
 		forSelect = select("#",...)
 	end


### PR DESCRIPTION
Назойливая ошибка возникает при овере на пустые категории в достижениях (Особый контент -> Фельярд или Исследования -> Фельярд). В forSelect хранится -1.#IND

![image](https://github.com/user-attachments/assets/30cb4f5d-3fec-4d67-99cc-4be20f70ee7e)
