### PR TITLE
Добавлен "Дикий сталецвет" в режим инвентаря "распыление"

### DIFF
--- a/Modules/Bags/Deconstruct.lua
+++ b/Modules/Bags/Deconstruct.lua
@@ -109,6 +109,7 @@ local millableHerbs = {
 	[2453] = true, -- Bruiseweed
 	[3820] = true, -- Stranglekelp
 	[3369] = true, -- Grave Moss
+	[3355] = true, -- Wild Steelbloom
 	[3356] = true, -- Kingsblood
 	[3357] = true, -- Liferoot
 	[3818] = true, -- Fadeleaf


### PR DESCRIPTION
В инвентаре, при активации "режима распыления", трава "Дикий сталецвет" не подсвечивалась и следовательно этим способом её нельзя было измельчить.