### PR TITLE
BP & Store scale on 2k

### DIFF
--- a/Modules/Skins/Blizzard_Sirus/Sirus_BattlePass.lua
+++ b/Modules/Skins/Blizzard_Sirus/Sirus_BattlePass.lua
@@ -3,6 +3,15 @@ local S = E:GetModule("Skins")
 
 local _G = _G
 
+local function GetBattlePassFrameScale()
+	local parentScale = E.global.general.UIScale or (UIParent and UIParent:GetScale()) or 1
+	if parentScale > 0 and parentScale < 0.7 and (GetScreenWidth() >= 2560 or GetScreenHeight() >= 1440) then
+		return 0.75
+	end
+
+	return parentScale
+end
+
 local function ApplyElvUIFont(frame)
 	if not frame or not frame.GetNumRegions then
 		return
@@ -252,7 +261,7 @@ local function HandleBattlePassFrame()
 	if not f._Elv_ScaleHooked then
 		f._Elv_ScaleHooked = true
 		f:HookScript("OnShow", function(self)
-			self:SetScale(E.global.general.UIScale)
+			self:SetScale(GetBattlePassFrameScale())
 		end)
 	end
 

--- a/Modules/Skins/Blizzard_Sirus/Sirus_Store.lua
+++ b/Modules/Skins/Blizzard_Sirus/Sirus_Store.lua
@@ -1,6 +1,15 @@
 local E, L, V, P, G = unpack(select(2, ...)); --Import: Engine, Locales, PrivateDB, ProfileDB, GlobalDB
 local S = E:GetModule("Skins")
 
+local function GetStoreFrameScale()
+	local parentScale = UIParent and UIParent:GetScale() or 1
+	if parentScale > 0 and parentScale < 0.7 and (GetScreenWidth() >= 2560 or GetScreenHeight() >= 1440) then
+		return 0.75
+	end
+
+	return parentScale
+end
+
 --Lua functions
 --WoW API / Variables
 -- local function HookSubButtons()
@@ -17,7 +26,7 @@ local function LoadSkin()
 	if E.private.skins.blizzard.enable ~= true or E.private.skins.blizzard.store ~= true then return end
 
 	StoreFrame:HookScript("OnShow", function()
-		StoreFrame:SetScale(UIParent:GetScale())
+		StoreFrame:SetScale(GetStoreFrameScale())
 	end)
 	StoreFrame:EnableMouse(true)
 	StoreFrame:SetMovable(true)


### PR DESCRIPTION
в текущем состоянии БП и магазин просто не читаемы на 0.53 скейле

после изменений

<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/e7684abe-f9d9-4f7f-a763-2e0c6bbe94a2" />
<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/8f18e64e-ae92-4ae3-a8f3-7d26ccfd2a88" />

